### PR TITLE
Fix use of deprecated v8::Function::NewInstance API

### DIFF
--- a/src/NodeCommon.h
+++ b/src/NodeCommon.h
@@ -47,6 +47,18 @@ ROBOT_NS_USE_ALL;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#if NODE_MODULE_VERSION >= 46
+
+	#define NEW_INSTANCE( f, argc, argv ) f->NewInstance(v8::Context::New(isolate), argc, argv).ToLocalChecked()
+
+#else
+
+	#define NEW_INSTANCE( f, argc, argv ) f->NewInstance(argc, argv)
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+
 #define NEW_INT( value ) Integer::New         (isolate, value )
 #define NEW_NUM( value ) Number ::New         (isolate, value )
 #define NEW_BOOL(value ) Boolean::New         (isolate, value )
@@ -64,32 +76,28 @@ ROBOT_NS_USE_ALL;
 		_jsArgs[1] = NEW_INT (g),							\
 		_jsArgs[2] = NEW_INT (b),							\
 		_jsArgs[3] = NEW_INT (a),							\
-		Local<Function>::New								\
-			(isolate, JsColor)->NewInstance (4, _jsArgs)	\
+		NEW_INSTANCE(Local<Function>::New(isolate, JsColor), 4, _jsArgs) \
 	)
 
 #define NEW_RANGE( min, max )								\
 	(														\
 		_jsArgs[0] = NEW_INT (min),							\
 		_jsArgs[1] = NEW_INT (max),							\
-		Local<Function>::New								\
-			(isolate, JsRange)->NewInstance (2, _jsArgs)	\
+		NEW_INSTANCE(Local<Function>::New(isolate, JsRange), 2, _jsArgs) \
 	)
 
 #define NEW_POINT( x, y )									\
 	(														\
 		_jsArgs[0] = NEW_INT (x),							\
 		_jsArgs[1] = NEW_INT (y),							\
-		Local<Function>::New								\
-			(isolate, JsPoint)->NewInstance (2, _jsArgs)	\
+		NEW_INSTANCE(Local<Function>::New(isolate, JsPoint), 2, _jsArgs) \
 	)
 
 #define NEW_SIZE( w, h )									\
 	(														\
 		_jsArgs[0] = NEW_INT (w),							\
 		_jsArgs[1] = NEW_INT (h),							\
-		Local<Function>::New								\
-			(isolate, JsSize)->NewInstance (2, _jsArgs)		\
+		NEW_INSTANCE(Local<Function>::New(isolate, JsSize), 2, _jsArgs) \
 	)
 
 #define NEW_BOUNDS( x, y, w, h )							\
@@ -98,14 +106,13 @@ ROBOT_NS_USE_ALL;
 		_jsArgs[1] = NEW_INT (y),							\
 		_jsArgs[2] = NEW_INT (w),							\
 		_jsArgs[3] = NEW_INT (h),							\
-		Local<Function>::New								\
-			(isolate, JsBounds)->NewInstance (4, _jsArgs)	\
+		NEW_INSTANCE(Local<Function>::New(isolate, JsBounds), 4, _jsArgs) \
 	)
 
-#define NEW_MODULE  Local<Function>::New (isolate, JsModule )->NewInstance()
-#define NEW_SEGMENT Local<Function>::New (isolate, JsSegment)->NewInstance()
-#define NEW_STATS   Local<Function>::New (isolate, JsStats  )->NewInstance()
-#define NEW_REGION  Local<Function>::New (isolate, JsRegion )->NewInstance()
+#define NEW_MODULE  NEW_INSTANCE(Local<Function>::New(isolate, JsModule ), 0, NULL)
+#define NEW_SEGMENT NEW_INSTANCE(Local<Function>::New(isolate, JsSegment), 0, NULL)
+#define NEW_STATS   NEW_INSTANCE(Local<Function>::New(isolate, JsStats  ), 0, NULL)
+#define NEW_REGION  NEW_INSTANCE(Local<Function>::New(isolate, JsRegion ), 0, NULL)
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/NodeImage.cc
+++ b/src/NodeImage.cc
@@ -200,10 +200,10 @@ void ImageWrap::New (const FunctionCallbackInfo<Value>& args)
 		else
 		{
 			// Normalize the size argument
-			auto s = Local<Function>::New
-				(isolate, JsSize)->NewInstance
-				(2, (_jsArgs[0] = args[0],
-					 _jsArgs[1] = args[1], _jsArgs));
+			auto s = NEW_INSTANCE(
+				Local<Function>::New(isolate, JsSize),
+				2, (_jsArgs[0] = args[0],
+					_jsArgs[1] = args[1], _jsArgs));
 
 			wrapper->mImage.Create
 				((uint16) s->Get (NEW_STR ("w"))->Int32Value(),
@@ -218,7 +218,7 @@ void ImageWrap::New (const FunctionCallbackInfo<Value>& args)
 	{
 		auto ctor = NEW_CTOR (Image);
 		// Return as a new instance
-		RETURN (ctor->NewInstance (2,
+		RETURN (NEW_INSTANCE(ctor, 2,
 			   (_jsArgs[0] = args[0],
 				_jsArgs[1] = args[1], _jsArgs)));
 	}

--- a/src/NodeKeyboard.cc
+++ b/src/NodeKeyboard.cc
@@ -160,7 +160,7 @@ void KeyboardWrap::New (const FunctionCallbackInfo<Value>& args)
 	{
 		auto ctor = NEW_CTOR (Keyboard);
 		// Return as a new instance
-		RETURN (ctor->NewInstance());
+		RETURN (NEW_INSTANCE(ctor, 0, NULL));
 	}
 }
 

--- a/src/NodeMemory.cc
+++ b/src/NodeMemory.cc
@@ -57,7 +57,7 @@ void MemoryWrap::GetProcess (const FunctionCallbackInfo<Value>& args)
 	auto ctor = NEW_CTOR (Process);
 
 	// Create a new instance of wrapper
-	auto instance = ctor->NewInstance();
+	auto instance = NEW_INSTANCE(ctor, 0, NULL);
 	UNWRAP (Process, instance);
 
 	auto process = mMemory->GetProcess();
@@ -160,7 +160,7 @@ void MemoryWrap::GetRegions (const FunctionCallbackInfo<Value>& args)
 		const auto& current = list[i];
 
 		// Create a new region instance
-		auto obj = ctor->NewInstance();
+		auto obj = NEW_INSTANCE(ctor, 0, NULL);
 
 		obj->Set (NEW_STR ("valid"     ), NEW_BOOL (         current.Valid     ));
 		obj->Set (NEW_STR ("bound"     ), NEW_BOOL (         current.Bound     ));
@@ -602,7 +602,7 @@ void MemoryWrap::New (const FunctionCallbackInfo<Value>& args)
 	{
 		auto ctor = NEW_CTOR (Memory);
 		// Return as a new instance
-		RETURN (ctor->NewInstance (1,
+		RETURN (NEW_INSTANCE(ctor, 1,
 			   (_jsArgs[0] = args[0], _jsArgs)));
 	}
 }

--- a/src/NodeMouse.cc
+++ b/src/NodeMouse.cc
@@ -166,7 +166,7 @@ void MouseWrap::New (const FunctionCallbackInfo<Value>& args)
 	{
 		auto ctor = NEW_CTOR (Mouse);
 		// Return as a new instance
-		RETURN (ctor->NewInstance());
+		RETURN (NEW_INSTANCE(ctor, 0, NULL));
 	}
 }
 

--- a/src/NodeProcess.cc
+++ b/src/NodeProcess.cc
@@ -147,7 +147,7 @@ void ProcessWrap::GetModules (const FunctionCallbackInfo<Value>& args)
 		const auto& current = list[i];
 
 		// Create a new module instance
-		auto obj = ctor->NewInstance();
+		auto obj = NEW_INSTANCE(ctor, 0, NULL);
 
 		obj->Set (NEW_STR ("_valid"), NEW_BOOL (current.IsValid()));
 		obj->Set (NEW_STR ("_name" ), NEW_STR  (current.GetName().data()));
@@ -188,7 +188,7 @@ void ProcessWrap::GetWindows (const FunctionCallbackInfo<Value>& args)
 	for (int i = 0; i < length; ++i)
 	{
 		// Create a new instance of wrapper
-		auto instance = ctor->NewInstance();
+		auto instance = NEW_INSTANCE(ctor, 0, NULL);
 		UNWRAP (Window, instance);
 
 		// Make wrapper use new window
@@ -237,7 +237,7 @@ void ProcessWrap::GetList (const FunctionCallbackInfo<Value>& args)
 	for (int i = 0; i < length; ++i)
 	{
 		// Create a new instance of wrapper
-		auto instance = ctor->NewInstance();
+		auto instance = NEW_INSTANCE(ctor, 0, NULL);
 		UNWRAP (Process, instance);
 
 		// Make wrapper use new process
@@ -256,7 +256,7 @@ void ProcessWrap::GetCurrent (const FunctionCallbackInfo<Value>& args)
 	auto ctor = NEW_CTOR (Process);
 
 	// Create a new instance of wrapper
-	auto instance = ctor->NewInstance();
+	auto instance = NEW_INSTANCE(ctor, 0, NULL);
 	UNWRAP (Process, instance);
 
 	auto process = Process::GetCurrent();
@@ -297,7 +297,7 @@ void ProcessWrap::GetSegments (const FunctionCallbackInfo<Value>& args)
 		const auto& current = list[i];
 
 		// Create a new module instance
-		auto obj = ctor->NewInstance();
+		auto obj = NEW_INSTANCE(ctor, 0, NULL);
 
 		obj->Set (NEW_STR ("valid"), NEW_BOOL (         current.Valid));
 		obj->Set (NEW_STR ("base" ), NEW_NUM  ((double) current.Base ));
@@ -338,7 +338,7 @@ void ProcessWrap::New (const FunctionCallbackInfo<Value>& args)
 	{
 		auto ctor = NEW_CTOR (Process);
 		// Return as a new instance
-		RETURN (ctor->NewInstance (1,
+		RETURN (NEW_INSTANCE(ctor, 1,
 			   (_jsArgs[0] = args[0], _jsArgs)));
 	}
 }

--- a/src/NodeWindow.cc
+++ b/src/NodeWindow.cc
@@ -129,7 +129,7 @@ void WindowWrap::GetProcess (const FunctionCallbackInfo<Value>& args)
 	auto ctor = NEW_CTOR (Process);
 
 	// Create a new instance of wrapper
-	auto instance = ctor->NewInstance();
+	auto instance = NEW_INSTANCE(ctor, 0, NULL);
 	UNWRAP (Process, instance);
 
 	auto process = mWindow->GetProcess();
@@ -306,7 +306,7 @@ void WindowWrap::GetList (const FunctionCallbackInfo<Value>& args)
 	for (int i = 0; i < length; ++i)
 	{
 		// Create a new instance of wrapper
-		auto instance = ctor->NewInstance();
+		auto instance = NEW_INSTANCE(ctor, 0, NULL);
 		UNWRAP (Window, instance);
 
 		// Make wrapper use new window
@@ -325,7 +325,7 @@ void WindowWrap::GetActive (const FunctionCallbackInfo<Value>& args)
 	auto ctor = NEW_CTOR (Window);
 
 	// Create a new instance of wrapper
-	auto instance = ctor->NewInstance();
+	auto instance = NEW_INSTANCE(ctor, 0, NULL);
 	UNWRAP (Window, instance);
 
 	auto window = Window::GetActive();
@@ -389,7 +389,7 @@ void WindowWrap::New (const FunctionCallbackInfo<Value>& args)
 	{
 		auto ctor = NEW_CTOR (Window);
 		// Return as a new instance
-		RETURN (ctor->NewInstance (1,
+		RETURN (NEW_INSTANCE(ctor, 1,
 			   (_jsArgs[0] = args[0], _jsArgs)));
 	}
 }


### PR DESCRIPTION
Fixes #66 

Fixup is applied for ABI >= 46 (Node v4.0.0), since that is the point in the mainline Node versions where the new method signature was introduced as the preferred one (even though the old signature remained supported-but-deprecated up until ABI == 59).